### PR TITLE
[Issue #6] Adds initial tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# PyCharm project directory
+.idea/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Above code snippets searches for images containing ubuntu in description
 or slug. Since region is specified (sgp1), only images in sgp1 region
 would be considered. If no region is specified all regions are included.
 
+Tests:
+
+    >>> tox
+
+To run tests, run `tox` in the root directory of the repo. It will create
+virtual environments specified in `tox.ini`, install dependancies, and
+run pytest.
+
 Credits
 =======
 

--- a/dosa/__init__.py
+++ b/dosa/__init__.py
@@ -1,9 +1,12 @@
-from collections import namedtuple
 import glob
 import json
 import logging
+import math
 import os
+
 from os.path import basename
+from collections import namedtuple
+
 import requests
 
 API_VERSION = 'v2'
@@ -86,7 +89,7 @@ class Collection(APIObject):
         resp = self.list()
         images.extend(resp.result[self.name])
         total = resp.result['meta']['total']
-        more_no_reqs = total / len(images)
+        more_no_reqs = math.ceil(total / len(images))
         for i in range(more_no_reqs):
             resp = self.list(page=(i+2))
             images.extend(resp.result[self.name])

--- a/dosa/more.py
+++ b/dosa/more.py
@@ -29,7 +29,7 @@ def test_ssh(host, throw=False):
     except socket.timeout:
         if throw:
             raise
-    except socket.error, e:
+    except socket.error as e:
         if throw or e.errno != 111:
             raise
     finally:

--- a/dosa/tests/api_sample_data/domain_record.json
+++ b/dosa/tests/api_sample_data/domain_record.json
@@ -1,0 +1,14 @@
+{
+  "domain_record": {
+    "id": 28448433,
+    "type": "A",
+    "name": "www",
+    "data": "162.10.66.0",
+    "priority": null,
+    "port": null,
+    "ttl": 1800,
+    "weight": null,
+    "flags": null,
+    "tag": null
+  }
+}

--- a/dosa/tests/api_sample_data/domains.json
+++ b/dosa/tests/api_sample_data/domains.json
@@ -1,0 +1,14 @@
+{
+  "domains": [
+    {
+      "name": "example.com",
+      "ttl": 1800,
+      "zone_file": "$ORIGIN example.com.\n$TTL 1800\nexample.com. IN SOA ns1.digitalocean.com. hostmaster.example.com. 1415982609 10800 3600 604800 1800\nexample.com. 1800 IN NS ns1.digitalocean.com.\nexample.com. 1800 IN NS ns2.digitalocean.com.\nexample.com. 1800 IN NS ns3.digitalocean.com.\nexample.com. 1800 IN A 1.2.3.4\n"
+    }
+  ],
+  "links": {
+  },
+  "meta": {
+    "total": 1
+  }
+}

--- a/dosa/tests/api_sample_data/droplet_by_id.json
+++ b/dosa/tests/api_sample_data/droplet_by_id.json
@@ -1,0 +1,100 @@
+{
+  "droplet": {
+    "id": 3164494,
+    "name": "example.com",
+    "memory": 512,
+    "vcpus": 1,
+    "disk": 20,
+    "locked": false,
+    "status": "active",
+    "kernel": {
+      "id": 2233,
+      "name": "Ubuntu 14.04 x64 vmlinuz-3.13.0-37-generic",
+      "version": "3.13.0-37-generic"
+    },
+    "created_at": "2014-11-14T16:36:31Z",
+    "features": [
+      "ipv6",
+      "virtio"
+    ],
+    "backup_ids": [
+
+    ],
+    "snapshot_ids": [
+      7938206
+    ],
+    "image": {
+      "id": 6918990,
+      "name": "14.04 x64",
+      "distribution": "Ubuntu",
+      "slug": "ubuntu-14-04-x64",
+      "public": true,
+      "regions": [
+        "nyc1",
+        "ams1",
+        "sfo1",
+        "nyc2",
+        "ams2",
+        "sgp1",
+        "lon1",
+        "nyc3",
+        "ams3",
+        "nyc3"
+      ],
+      "created_at": "2014-10-17T20:24:33Z",
+      "type": "snapshot",
+      "min_disk_size": 20,
+      "size_gigabytes": 2.34
+    },
+    "volume_ids": [
+
+    ],
+    "size": {
+    },
+    "size_slug": "512mb",
+    "networks": {
+      "v4": [
+        {
+          "ip_address": "104.131.186.241",
+          "netmask": "255.255.240.0",
+          "gateway": "104.131.176.1",
+          "type": "public"
+        }
+      ],
+      "v6": [
+        {
+          "ip_address": "2604:A880:0800:0010:0000:0000:031D:2001",
+          "netmask": 64,
+          "gateway": "2604:A880:0800:0010:0000:0000:0000:0001",
+          "type": "public"
+        }
+      ]
+    },
+    "region": {
+      "name": "New York 3",
+      "slug": "nyc3",
+      "sizes": [
+        "32gb",
+        "16gb",
+        "2gb",
+        "1gb",
+        "4gb",
+        "8gb",
+        "512mb",
+        "64gb",
+        "48gb"
+      ],
+      "features": [
+        "virtio",
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "available": true
+    },
+    "tags": [
+
+    ]
+  }
+}

--- a/dosa/tests/api_sample_data/droplet_create.json
+++ b/dosa/tests/api_sample_data/droplet_create.json
@@ -1,0 +1,50 @@
+{
+  "droplet": {
+    "id": 3164494,
+    "name": "example.com",
+    "memory": 512,
+    "vcpus": 1,
+    "disk": 20,
+    "locked": true,
+    "status": "new",
+    "kernel": {
+      "id": 2233,
+      "name": "Ubuntu 14.04 x64 vmlinuz-3.13.0-37-generic",
+      "version": "3.13.0-37-generic"
+    },
+    "created_at": "2014-11-14T16:36:31Z",
+    "features": [
+      "virtio"
+    ],
+    "backup_ids": [
+
+    ],
+    "snapshot_ids": [
+
+    ],
+    "image": {
+    },
+    "volume_ids": [
+
+    ],
+    "size": {
+    },
+    "size_slug": "512mb",
+    "networks": {
+    },
+    "region": {
+    },
+    "tags": [
+      "web"
+    ]
+  },
+  "links": {
+    "actions": [
+      {
+        "id": 36805096,
+        "rel": "create",
+        "href": "https://api.digitalocean.com/v2/actions/36805096"
+      }
+    ]
+  }
+}

--- a/dosa/tests/api_sample_data/droplets.json
+++ b/dosa/tests/api_sample_data/droplets.json
@@ -1,0 +1,104 @@
+{
+  "droplets": [
+    {
+      "id": 3164444,
+      "name": "example.com",
+      "memory": 512,
+      "vcpus": 1,
+      "disk": 20,
+      "locked": false,
+      "status": "active",
+      "kernel": {
+        "id": 2233,
+        "name": "Ubuntu 14.04 x64 vmlinuz-3.13.0-37-generic",
+        "version": "3.13.0-37-generic"
+      },
+      "created_at": "2014-11-14T16:29:21Z",
+      "features": [
+        "backups",
+        "ipv6",
+        "virtio"
+      ],
+      "backup_ids": [
+        7938002
+      ],
+      "snapshot_ids": [
+
+      ],
+      "image": {
+        "id": 6918990,
+        "name": "14.04 x64",
+        "distribution": "Ubuntu",
+        "slug": "ubuntu-14-04-x64",
+        "public": true,
+        "regions": [
+          "nyc1",
+          "ams1",
+          "sfo1",
+          "nyc2",
+          "ams2",
+          "sgp1",
+          "lon1",
+          "nyc3",
+          "ams3",
+          "nyc3"
+        ],
+        "created_at": "2014-10-17T20:24:33Z",
+        "type": "snapshot",
+        "min_disk_size": 20,
+        "size_gigabytes": 2.34
+      },
+      "volume_ids": [
+
+      ],
+      "size": {
+      },
+      "size_slug": "512mb",
+      "networks": {
+        "v4": [
+          {
+            "ip_address": "104.236.32.182",
+            "netmask": "255.255.192.0",
+            "gateway": "104.236.0.1",
+            "type": "public"
+          }
+        ],
+        "v6": [
+          {
+            "ip_address": "2604:A880:0800:0010:0000:0000:02DD:4001",
+            "netmask": 64,
+            "gateway": "2604:A880:0800:0010:0000:0000:0000:0001",
+            "type": "public"
+          }
+        ]
+      },
+      "region": {
+        "name": "New York 3",
+        "slug": "nyc3",
+        "sizes": [
+
+        ],
+        "features": [
+          "virtio",
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata"
+        ],
+        "available": null
+      },
+      "tags": [
+
+      ]
+    }
+  ],
+  "links": {
+    "pages": {
+      "last": "https://api.digitalocean.com/v2/droplets?page=3&per_page=1",
+      "next": "https://api.digitalocean.com/v2/droplets?page=2&per_page=1"
+    }
+  },
+  "meta": {
+    "total": 3
+  }
+}

--- a/dosa/tests/api_sample_data/images.json
+++ b/dosa/tests/api_sample_data/images.json
@@ -1,0 +1,28 @@
+{
+  "images": [
+    {
+      "id": 7555620,
+      "name": "Nifty New Snapshot",
+      "distribution": "Ubuntu",
+      "slug": null,
+      "public": false,
+      "regions": [
+        "nyc2",
+        "nyc2"
+      ],
+      "created_at": "2014-11-04T22:23:02Z",
+      "type": "snapshot",
+      "min_disk_size": 20,
+      "size_gigabytes": 2.34
+    }
+  ],
+  "links": {
+    "pages": {
+      "last": "https://api.digitalocean.com/v2/images?page=56&per_page=1",
+      "next": "https://api.digitalocean.com/v2/images?page=2&per_page=1"
+    }
+  },
+  "meta": {
+    "total": 56
+  }
+}

--- a/dosa/tests/api_sample_data/images_search.json
+++ b/dosa/tests/api_sample_data/images_search.json
@@ -1,0 +1,24 @@
+{
+  "image": {
+    "id": 6918990,
+    "name": "14.04 x64",
+    "distribution": "Ubuntu",
+    "slug": "ubuntu-14-04-x64",
+    "public": true,
+    "regions": [
+      "nyc1",
+      "ams1",
+      "sfo1",
+      "nyc2",
+      "ams2",
+      "sgp1",
+      "lon1",
+      "nyc3",
+      "ams3",
+      "nyc3"
+    ],
+    "created_at": "2014-10-17T20:24:33Z",
+    "min_disk_size": 20,
+    "size_gigabytes": 2.34
+  }
+}

--- a/dosa/tests/api_sample_data/keys.json
+++ b/dosa/tests/api_sample_data/keys.json
@@ -1,0 +1,15 @@
+{
+  "ssh_keys": [
+    {
+      "id": 512189,
+      "fingerprint": "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa",
+      "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example",
+      "name": "My SSH Public Key"
+    }
+  ],
+  "links": {
+  },
+  "meta": {
+    "total": 1
+  }
+}

--- a/dosa/tests/api_sample_data/keys_create.json
+++ b/dosa/tests/api_sample_data/keys_create.json
@@ -1,0 +1,8 @@
+{
+  "ssh_key": {
+    "id": 512190,
+    "fingerprint": "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa",
+    "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example",
+    "name": "My SSH Public Key"
+  }
+}

--- a/dosa/tests/test_domain_actions.py
+++ b/dosa/tests/test_domain_actions.py
@@ -1,0 +1,93 @@
+import json
+import os.path
+from unittest import TestCase
+from unittest.mock import patch
+
+import dosa
+
+endpoint = 'https://api.digitalocean.com/%s' % dosa.API_VERSION
+api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
+
+class TestDosaClientDomainActions(TestCase):
+    @classmethod
+    def setUp(self):
+        self.api_key = "my_fake_api_key"
+        self.client = dosa.Client(self.api_key)
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def test_dosa_client_created(self):
+        client = dosa.Client(self.api_key)
+        self.assertIsInstance(client, dosa.Client)
+
+    @patch('dosa.requests.get')
+    def test_dosa_domain_list(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = json.loads(self._get_sample_data('domains'))
+        status, result = self.client.domains.list()
+        self.assertEqual(1, len(result['domains']))
+        self.assertTrue(mock_get.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{}'
+        url, data = mock_get.call_args
+        self.assertEqual(url[0], "{}/domains".format(endpoint))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+    @patch('dosa.requests.post')
+    def test_dosa_domain_create(self, mock_post):
+        mock_post.return_value.status_code = 202
+        mocked_return = {
+            'domain': {
+                'name': 'example.com',
+                'ttl': 1800,
+                'zone_file': 'null'
+            }
+        }
+        mock_post.return_value.json.return_value = mocked_return
+        status, result = self.client.domains.create(name="example.com", ip_address="1.2.3.4")
+        self.assertTrue(mock_post.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        url, data = mock_post.call_args
+        self.assertEqual(url[0], "{}/domains".format(endpoint))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        data_json = json.loads(data['data'])
+        self.assertEqual(data_json['name'], mocked_return['domain']['name'])
+
+    @patch('dosa.requests.delete')
+    def test_dosa_domain_delete(self, mock_delete):
+        mock_delete.return_value.status_code = 204
+        mock_delete.return_value.json.return_value = ''
+        domain_name = "example.com"
+        status, result = self.client.domains.delete(domain_name)
+
+        self.assertTrue(mock_delete.called)
+        self.assertEqual(result, None)
+        self.assertEqual(status, 204)
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+
+        url, data = mock_delete.call_args
+        self.assertEqual(url[0], "{}/domains/{}".format(endpoint, domain_name))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+
+    def _get_sample_data(self, path=''):
+        return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_domain_actions.py
+++ b/dosa/tests/test_domain_actions.py
@@ -11,7 +11,7 @@ api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
 class TestDosaClientDomainActions(TestCase):
     @classmethod
     def setUp(self):
-        self.api_key = "my_fake_api_key"
+        self.api_key = 'my_fake_api_key'
         self.client = dosa.Client(self.api_key)
 
     @classmethod
@@ -37,10 +37,10 @@ class TestDosaClientDomainActions(TestCase):
         expected_params = {}
         expected_data = '{}'
         url, data = mock_get.call_args
-        self.assertEqual(url[0], "{}/domains".format(endpoint))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/domains'.format(endpoint))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
     @patch('dosa.requests.post')
     def test_dosa_domain_create(self, mock_post):
@@ -53,7 +53,7 @@ class TestDosaClientDomainActions(TestCase):
             }
         }
         mock_post.return_value.json.return_value = mocked_return
-        status, result = self.client.domains.create(name="example.com", ip_address="1.2.3.4")
+        status, result = self.client.domains.create(name='example.com', ip_address='1.2.3.4')
         self.assertTrue(mock_post.called)
 
         expected_headers = {
@@ -62,9 +62,9 @@ class TestDosaClientDomainActions(TestCase):
         }
         expected_params = {}
         url, data = mock_post.call_args
-        self.assertEqual(url[0], "{}/domains".format(endpoint))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(url[0], '{}/domains'.format(endpoint))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
         data_json = json.loads(data['data'])
         self.assertEqual(data_json['name'], mocked_return['domain']['name'])
 
@@ -72,7 +72,7 @@ class TestDosaClientDomainActions(TestCase):
     def test_dosa_domain_delete(self, mock_delete):
         mock_delete.return_value.status_code = 204
         mock_delete.return_value.json.return_value = ''
-        domain_name = "example.com"
+        domain_name = 'example.com'
         status, result = self.client.domains.delete(domain_name)
 
         self.assertTrue(mock_delete.called)
@@ -85,9 +85,9 @@ class TestDosaClientDomainActions(TestCase):
         expected_params = {}
 
         url, data = mock_delete.call_args
-        self.assertEqual(url[0], "{}/domains/{}".format(endpoint, domain_name))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(url[0], '{}/domains/{}'.format(endpoint, domain_name))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
 
     def _get_sample_data(self, path=''):
         return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_domain_records.py
+++ b/dosa/tests/test_domain_records.py
@@ -11,7 +11,7 @@ api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
 class TestDosaClientDomainRecordActions(TestCase):
     @classmethod
     def setUp(self):
-        self.api_key = "my_fake_api_key"
+        self.api_key = 'my_fake_api_key'
         self.client = dosa.Client(self.api_key)
 
     @classmethod
@@ -26,7 +26,7 @@ class TestDosaClientDomainRecordActions(TestCase):
     def test_get_domain_record(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = json.loads(self._get_sample_data('domain_record'))
-        domain_name = "example.com"
+        domain_name = 'example.com'
         dr = self.client.DomainRecords(domain=domain_name)
         dr.list()
         self.assertTrue(mock_get.called)
@@ -38,10 +38,10 @@ class TestDosaClientDomainRecordActions(TestCase):
         expected_params = {}
         expected_data = '{}'
         url, data = mock_get.call_args
-        self.assertEqual(url[0], "{}/domains/{}/records".format(endpoint, domain_name))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/domains/{}/records'.format(endpoint, domain_name))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
     @patch('dosa.requests.post')
     def test_dosa_domain_record_create(self, mock_post):
@@ -59,9 +59,9 @@ class TestDosaClientDomainRecordActions(TestCase):
         }
         expected_params = {}
         url, data = mock_post.call_args
-        self.assertEqual(url[0], "{}/domains/{}/records".format(endpoint, domain_name))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(url[0], '{}/domains/{}/records'.format(endpoint, domain_name))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
         data_dict = json.loads(data['data'])
         self.assertEqual(data_dict['data'], mocked_return['domain_record']['data'])
 
@@ -69,7 +69,7 @@ class TestDosaClientDomainRecordActions(TestCase):
     def test_dosa_update_domain_record_by_id(self, mock_put):
         mock_put.return_value.status_code = 200
         mock_put.return_value.json.return_value = json.loads(self._get_sample_data('domain_record'))
-        domain_name = "example.com"
+        domain_name = 'example.com'
         domain_record = 28448433
         dr = self.client.DomainRecords(domain=domain_name)
         record = dr.Record(record_id=domain_record)
@@ -83,10 +83,10 @@ class TestDosaClientDomainRecordActions(TestCase):
         expected_params = {}
         expected_data = '{"name": "www"}'
         url, data = mock_put.call_args
-        self.assertEqual(url[0], "{}/domains/{}/records/{}".format(endpoint, domain_name, domain_record))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/domains/{}/records/{}'.format(endpoint, domain_name, domain_record))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
 
     def _get_sample_data(self, path=''):

--- a/dosa/tests/test_domain_records.py
+++ b/dosa/tests/test_domain_records.py
@@ -1,0 +1,93 @@
+import json
+import os.path
+from unittest import TestCase
+from unittest.mock import patch
+
+import dosa
+
+endpoint = 'https://api.digitalocean.com/%s' % dosa.API_VERSION
+api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
+
+class TestDosaClientDomainRecordActions(TestCase):
+    @classmethod
+    def setUp(self):
+        self.api_key = "my_fake_api_key"
+        self.client = dosa.Client(self.api_key)
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def test_dosa_client_created(self):
+        client = dosa.Client(self.api_key)
+        self.assertIsInstance(client, dosa.Client)
+
+    @patch('dosa.requests.get')
+    def test_get_domain_record(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = json.loads(self._get_sample_data('domain_record'))
+        domain_name = "example.com"
+        dr = self.client.DomainRecords(domain=domain_name)
+        dr.list()
+        self.assertTrue(mock_get.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{}'
+        url, data = mock_get.call_args
+        self.assertEqual(url[0], "{}/domains/{}/records".format(endpoint, domain_name))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+    @patch('dosa.requests.post')
+    def test_dosa_domain_record_create(self, mock_post):
+        mock_post.return_value.status_code = 201
+        mocked_return = json.loads(self._get_sample_data('domain_record'))
+        mock_post.return_value.json.return_value = mocked_return
+        domain_name = 'example.com'
+        dr = self.client.DomainRecords(domain=domain_name)
+        dr.create(type='A', name=domain_name, data='162.10.66.0')
+        self.assertTrue(mock_post.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        url, data = mock_post.call_args
+        self.assertEqual(url[0], "{}/domains/{}/records".format(endpoint, domain_name))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        data_dict = json.loads(data['data'])
+        self.assertEqual(data_dict['data'], mocked_return['domain_record']['data'])
+
+    @patch('dosa.requests.put')
+    def test_dosa_update_domain_record_by_id(self, mock_put):
+        mock_put.return_value.status_code = 200
+        mock_put.return_value.json.return_value = json.loads(self._get_sample_data('domain_record'))
+        domain_name = "example.com"
+        domain_record = 28448433
+        dr = self.client.DomainRecords(domain=domain_name)
+        record = dr.Record(record_id=domain_record)
+        record.update(name='www')
+        self.assertTrue(mock_put.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{"name": "www"}'
+        url, data = mock_put.call_args
+        self.assertEqual(url[0], "{}/domains/{}/records/{}".format(endpoint, domain_name, domain_record))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+
+    def _get_sample_data(self, path=''):
+        return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_droplet_actions.py
+++ b/dosa/tests/test_droplet_actions.py
@@ -11,7 +11,7 @@ api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
 class TestDosaClientDropletActions(TestCase):
     @classmethod
     def setUp(self):
-        self.api_key = "my_fake_api_key"
+        self.api_key = 'my_fake_api_key'
         self.client = dosa.Client(self.api_key)
 
     @classmethod
@@ -37,10 +37,10 @@ class TestDosaClientDropletActions(TestCase):
         expected_params = {}
         expected_data = '{}'
         url, data = mock_get.call_args
-        self.assertEqual(url[0], "{}/droplets".format(endpoint))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/droplets'.format(endpoint))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
     @patch('dosa.requests.post')
     def test_dosa_droplet_create(self, mock_post):
@@ -59,17 +59,17 @@ class TestDosaClientDropletActions(TestCase):
         }
         expected_params = {}
         expected_data = {
-            "name": "terminator",
-            "region": "nyc2",
-            "size": "512mb",
-            "image": "ubuntu-14-04-x32",
-            "ssh_keys": [12345]
+            'name': 'terminator',
+            'region': 'nyc2',
+            'size': '512mb',
+            'image': 'ubuntu-14-04-x32',
+            'ssh_keys': [12345]
         }
         url, data = mock_post.call_args
-        self.assertEqual(url[0], "{}/droplets".format(endpoint))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        received_data = json.loads(data["data"])
+        self.assertEqual(url[0], '{}/droplets'.format(endpoint))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        received_data = json.loads(data['data'])
         # assert that expected data was returned in sample data
         for key, value in expected_data.items():
             self.assertEqual(received_data[key], value)
@@ -79,9 +79,9 @@ class TestDosaClientDropletActions(TestCase):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = json.loads(self._get_sample_data('droplet_by_id'))
         data_sample = json.loads(self._get_sample_data('droplet_by_id'))
-        droplet_id = data_sample["droplet"]["id"]
-        droplet_ips = [ip["ip_address"] for ip in data_sample["droplet"]["networks"]["v4"]]
-        droplet_status = data_sample["droplet"]["status"]
+        droplet_id = data_sample['droplet']['id']
+        droplet_ips = [ip['ip_address'] for ip in data_sample['droplet']['networks']['v4']]
+        droplet_status = data_sample['droplet']['status']
         droplet = self.client.Droplet(droplet_id)
         status, droplet_info = droplet.info()
         self.assertEqual(droplet_id, droplet_info['droplet']['id'])
@@ -95,10 +95,10 @@ class TestDosaClientDropletActions(TestCase):
         expected_params = {}
         expected_data = '{}'
         url, data = mock_get.call_args
-        self.assertEqual(url[0], "{}/droplets/{}".format(endpoint, droplet_id))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/droplets/{}'.format(endpoint, droplet_id))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
     @patch('dosa.requests.delete')
     def test_dosa_droplet_delete(self, mock_delete):
@@ -117,9 +117,9 @@ class TestDosaClientDropletActions(TestCase):
         expected_params = {}
 
         url, data = mock_delete.call_args
-        self.assertEqual(url[0], "{}/droplets/{}".format(endpoint, droplet_id))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(url[0], '{}/droplets/{}'.format(endpoint, droplet_id))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
 
     def _get_sample_data(self, path=''):
         return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_droplet_actions.py
+++ b/dosa/tests/test_droplet_actions.py
@@ -1,0 +1,125 @@
+import json
+import os.path
+from unittest import TestCase
+from unittest.mock import patch
+
+import dosa
+
+endpoint = 'https://api.digitalocean.com/%s' % dosa.API_VERSION
+api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
+
+class TestDosaClientDropletActions(TestCase):
+    @classmethod
+    def setUp(self):
+        self.api_key = "my_fake_api_key"
+        self.client = dosa.Client(self.api_key)
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def test_dosa_client_created(self):
+        client = dosa.Client(self.api_key)
+        self.assertIsInstance(client, dosa.Client)
+
+    @patch('dosa.requests.get')
+    def test_dosa_droplet_list(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = json.loads(self._get_sample_data('droplets'))
+        status, result = self.client.droplets.list()
+        self.assertEqual(1, len(result['droplets']))
+        self.assertTrue(mock_get.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{}'
+        url, data = mock_get.call_args
+        self.assertEqual(url[0], "{}/droplets".format(endpoint))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+    @patch('dosa.requests.post')
+    def test_dosa_droplet_create(self, mock_post):
+        mock_post.return_value.status_code = 202
+        mock_post.return_value.json.return_value = json.loads(self._get_sample_data('droplet_create'))
+        status, result = self.client.droplets.create(name='terminator',
+                                                     region='nyc2',
+                                                     size='512mb',
+                                                     image='ubuntu-14-04-x32',
+                                                     ssh_keys=[12345])
+        self.assertTrue(mock_post.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = {
+            "name": "terminator",
+            "region": "nyc2",
+            "size": "512mb",
+            "image": "ubuntu-14-04-x32",
+            "ssh_keys": [12345]
+        }
+        url, data = mock_post.call_args
+        self.assertEqual(url[0], "{}/droplets".format(endpoint))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        received_data = json.loads(data["data"])
+        # assert that expected data was returned in sample data
+        for key, value in expected_data.items():
+            self.assertEqual(received_data[key], value)
+
+    @patch('dosa.requests.get')
+    def test_dosa_droplet_by_id(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = json.loads(self._get_sample_data('droplet_by_id'))
+        data_sample = json.loads(self._get_sample_data('droplet_by_id'))
+        droplet_id = data_sample["droplet"]["id"]
+        droplet_ips = [ip["ip_address"] for ip in data_sample["droplet"]["networks"]["v4"]]
+        droplet_status = data_sample["droplet"]["status"]
+        droplet = self.client.Droplet(droplet_id)
+        status, droplet_info = droplet.info()
+        self.assertEqual(droplet_id, droplet_info['droplet']['id'])
+        self.assertTrue(mock_get.called)
+        self.assertEqual(droplet_status, droplet.status())
+        self.assertListEqual(droplet_ips, droplet.ip_addresses())
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{}'
+        url, data = mock_get.call_args
+        self.assertEqual(url[0], "{}/droplets/{}".format(endpoint, droplet_id))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+    @patch('dosa.requests.delete')
+    def test_dosa_droplet_delete(self, mock_delete):
+        mock_delete.return_value.status_code = 204
+        mock_delete.return_value.json.return_value = ''
+        droplet_id = 12345
+        status, result = self.client.droplets.delete(droplet_id)
+
+        self.assertTrue(mock_delete.called)
+        self.assertEqual(result, None)
+        self.assertEqual(status, 204)
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+
+        url, data = mock_delete.call_args
+        self.assertEqual(url[0], "{}/droplets/{}".format(endpoint, droplet_id))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+
+    def _get_sample_data(self, path=''):
+        return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_image_actions.py
+++ b/dosa/tests/test_image_actions.py
@@ -1,0 +1,71 @@
+import json
+import os.path
+from unittest import TestCase
+from unittest.mock import patch
+
+import dosa
+
+endpoint = 'https://api.digitalocean.com/%s' % dosa.API_VERSION
+api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
+
+class TestDosaClientDropletActions(TestCase):
+    @classmethod
+    def setUp(self):
+        self.api_key = "my_fake_api_key"
+        self.client = dosa.Client(self.api_key)
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def test_dosa_client_created(self):
+        client = dosa.Client(self.api_key)
+        self.assertIsInstance(client, dosa.Client)
+
+    @patch('dosa.requests.get')
+    def test_dosa_image_list(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = json.loads(self._get_sample_data('images'))
+        status, result = self.client.images.list()
+        self.assertEqual(1, len(result['images']))
+        self.assertTrue(mock_get.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{}'
+        url, data = mock_get.call_args
+        self.assertEqual(url[0], "{}/images".format(endpoint))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+
+    @patch('dosa.requests.get')
+    def test_dosa_image_by_search(self, mock_get):
+        # TODO: Update library and test
+        # Currently failing due to dosa/__init__.py L159 attempting to use name 'images' from response with 'image' key
+        raise NotImplementedError
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = json.loads(self._get_sample_data('images_search'))
+        data_sample = json.loads(self._get_sample_data('images_search'))
+        image_slug = data_sample["image"]["slug"]
+        image = self.client.images.search('ubuntu')
+        status, image_info = image.info()
+        self.assertTrue(mock_get.called)
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{}'
+        url, data = mock_get.call_args
+        self.assertEqual(url[0], "{}/images/{}".format(endpoint, image_id))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+    def _get_sample_data(self, path=''):
+        return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_image_actions.py
+++ b/dosa/tests/test_image_actions.py
@@ -11,7 +11,7 @@ api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
 class TestDosaClientDropletActions(TestCase):
     @classmethod
     def setUp(self):
-        self.api_key = "my_fake_api_key"
+        self.api_key = 'my_fake_api_key'
         self.client = dosa.Client(self.api_key)
 
     @classmethod
@@ -37,21 +37,20 @@ class TestDosaClientDropletActions(TestCase):
         expected_params = {}
         expected_data = '{}'
         url, data = mock_get.call_args
-        self.assertEqual(url[0], "{}/images".format(endpoint))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/images'.format(endpoint))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
 
     @patch('dosa.requests.get')
     def test_dosa_image_by_search(self, mock_get):
         # TODO: Update library and test
         # Currently failing due to dosa/__init__.py L159 attempting to use name 'images' from response with 'image' key
-        raise NotImplementedError
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = json.loads(self._get_sample_data('images_search'))
         data_sample = json.loads(self._get_sample_data('images_search'))
-        image_slug = data_sample["image"]["slug"]
+        image_slug = data_sample['image']['slug']
         image = self.client.images.search('ubuntu')
         status, image_info = image.info()
         self.assertTrue(mock_get.called)
@@ -62,10 +61,10 @@ class TestDosaClientDropletActions(TestCase):
         expected_params = {}
         expected_data = '{}'
         url, data = mock_get.call_args
-        self.assertEqual(url[0], "{}/images/{}".format(endpoint, image_id))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/images/{}'.format(endpoint, image_id))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
     def _get_sample_data(self, path=''):
         return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_key_actions.py
+++ b/dosa/tests/test_key_actions.py
@@ -11,7 +11,7 @@ api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
 class TestDosaClientKeyActions(TestCase):
     @classmethod
     def setUp(self):
-        self.api_key = "my_fake_api_key"
+        self.api_key = 'my_fake_api_key'
         self.client = dosa.Client(self.api_key)
 
     @classmethod
@@ -24,8 +24,8 @@ class TestDosaClientKeyActions(TestCase):
 
     @patch('dosa.requests.post')
     def test_dosa_key_create(self, mock_post):
-        ssh_key_name = "MyFakeSSHKey"
-        ssh_key_value = "myfakesshkey"
+        ssh_key_name = 'MyFakeSSHKey'
+        ssh_key_value = 'myfakesshkey'
         mock_post.return_value.status_code = 201
         mock_post.return_value.json.return_value = json.loads(self._get_sample_data('keys_create'))
         status, result = self.client.keys.create(name=ssh_key_name, public_key=ssh_key_value)
@@ -38,14 +38,14 @@ class TestDosaClientKeyActions(TestCase):
         }
         expected_params = {}
         expected_data = {
-            "name": ssh_key_name,
-            "public_key": ssh_key_value
+            'name': ssh_key_name,
+            'public_key': ssh_key_value
         }
         url, data = mock_post.call_args
-        self.assertEqual(url[0], "{}/account/keys".format(endpoint))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertDictEqual(json.loads(data["data"]), expected_data)
+        self.assertEqual(url[0], '{}/account/keys'.format(endpoint))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertDictEqual(json.loads(data['data']), expected_data)
 
     @patch('dosa.requests.get')
     def test_dosa_key_list(self, mock_get):
@@ -61,11 +61,11 @@ class TestDosaClientKeyActions(TestCase):
         expected_params = {}
         expected_data = '{}'
         url, data = mock_get.call_args
-        self.assertEqual(url[0], "{}/account/keys".format(endpoint))
-        self.assertDictEqual(data["headers"], expected_headers)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertDictEqual(data["params"], expected_params)
-        self.assertEqual(data["data"], expected_data)
+        self.assertEqual(url[0], '{}/account/keys'.format(endpoint))
+        self.assertDictEqual(data['headers'], expected_headers)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertDictEqual(data['params'], expected_params)
+        self.assertEqual(data['data'], expected_data)
 
     def _get_sample_data(self, path=''):
         return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()

--- a/dosa/tests/test_key_actions.py
+++ b/dosa/tests/test_key_actions.py
@@ -1,0 +1,72 @@
+import json
+import os.path
+from unittest import TestCase
+from unittest.mock import patch
+
+import dosa
+
+endpoint = 'https://api.digitalocean.com/%s' % dosa.API_VERSION
+api_sample_data = os.path.join(os.path.dirname(__file__), 'api_sample_data')
+
+class TestDosaClientKeyActions(TestCase):
+    @classmethod
+    def setUp(self):
+        self.api_key = "my_fake_api_key"
+        self.client = dosa.Client(self.api_key)
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def test_dosa_client_created(self):
+        client = dosa.Client(self.api_key)
+        self.assertIsInstance(client, dosa.Client)
+
+    @patch('dosa.requests.post')
+    def test_dosa_key_create(self, mock_post):
+        ssh_key_name = "MyFakeSSHKey"
+        ssh_key_value = "myfakesshkey"
+        mock_post.return_value.status_code = 201
+        mock_post.return_value.json.return_value = json.loads(self._get_sample_data('keys_create'))
+        status, result = self.client.keys.create(name=ssh_key_name, public_key=ssh_key_value)
+        self.assertEqual(1, len(result))
+        self.assertTrue(mock_post.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = {
+            "name": ssh_key_name,
+            "public_key": ssh_key_value
+        }
+        url, data = mock_post.call_args
+        self.assertEqual(url[0], "{}/account/keys".format(endpoint))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertDictEqual(json.loads(data["data"]), expected_data)
+
+    @patch('dosa.requests.get')
+    def test_dosa_key_list(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = json.loads(self._get_sample_data('keys'))
+        status, result = self.client.keys.list()
+        self.assertTrue(mock_get.called)
+
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'authorization': 'Bearer {}'.format(self.api_key)
+        }
+        expected_params = {}
+        expected_data = '{}'
+        url, data = mock_get.call_args
+        self.assertEqual(url[0], "{}/account/keys".format(endpoint))
+        self.assertDictEqual(data["headers"], expected_headers)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertDictEqual(data["params"], expected_params)
+        self.assertEqual(data["data"], expected_data)
+
+    def _get_sample_data(self, path=''):
+        return open(os.path.join(api_sample_data, '{}.json'.format(path))).read()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setup(
     author_email='pythonic@gmail.com',
     license="http://www.opensource.org/licenses/mit-license.php",
     test_suite="tests",
+    install_requires=['requests']
     )
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 pytest
-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py35
+
+[testenv]
+deps = -rrequirements.txt
+       -rtest-requirements.txt
+commands = pytest --capture no --verbose


### PR DESCRIPTION
Adds basic functional tests to functionality given in the README as per #6 .

Fairly big PR. Adds API output sample data which is read in tests to mock DigitalOcean output. Adds `tox.ini` for running tests. Currently only uses python 3.5 in tests as python version not specified in README.

One test, `dosa/tests/test_image_actions.py::TestDosaClientDropletActions::test_dosa_image_by_search`, is expected to fail as it raises a `NotImplementedError` as this function does not appear to work as expected, and results in an exception when running as given in the README. 

Tests are written to pass with existing functionality, which does not appear to be as intended given information in README. For example, the `client.droplet.list()` requires use of the `'droplet` key. Seemed best to include tests with current functionality and have seperate commits/PRs to update functionality and tests after a `Contributing.md` or further documentation is written. 